### PR TITLE
Ability to configure the percentiles sent to Librato

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ By default you can use `LIBRATO_USER` and `LIBRATO_TOKEN` to pass your account d
 * `LIBRATO_PROXY` - HTTP proxy to use when connecting to the Librato API (can also use the `https_proxy` or `http_proxy` environment variable commonly supported by Linux command line utilities)
 * `LIBRATO_AUTORUN` - set to `'0'` to prevent the reporter from starting, useful if you don't want `librato-rack` to start under certain circumstances
 * `LIBRATO_EVENT_MODE` - use with evented apps, see "Use with EventMachine" below
+* `LIBRATO_PERCENTILES` - the timing percentiles to capture. Default is p95. Provide as a comma separated list, e.g. `95,99`
 
 ##### Use a configuration object
 

--- a/lib/librato/rack.rb
+++ b/lib/librato/rack.rb
@@ -39,7 +39,7 @@ module Librato
   class Rack
     RECORD_RACK_BODY = <<-'EOS'
       group.increment 'total'
-      group.timing    'time', duration, percentile: 95
+      group.timing    'time', duration, percentile: config.percentiles
       group.increment 'slow' if duration > 200.0
     EOS
 

--- a/lib/librato/rack/configuration.rb
+++ b/lib/librato/rack/configuration.rb
@@ -16,7 +16,7 @@ module Librato
 
       attr_accessor :api_endpoint, :autorun, :disable_rack_metrics,
                     :flush_interval, :log_level, :log_prefix,
-                    :log_target, :proxy, :suites,
+                    :log_target, :percentiles, :proxy, :suites,
                     :tags, :token, :tracker, :user
       attr_reader :deprecations, :prefix
 
@@ -64,6 +64,7 @@ module Librato
         self.proxy = ENV['LIBRATO_PROXY'] || ENV['https_proxy'] || ENV['http_proxy']
         self.event_mode = ENV['LIBRATO_EVENT_MODE']
         self.suites = ENV['LIBRATO_SUITES'] || ''
+        self.percentiles = ENV['LIBRATO_PERCENTILES']&.split(',')&.map(&:to_i) || [95]
         check_deprecations
       end
 

--- a/test/unit/rack/configuration_test.rb
+++ b/test/unit/rack/configuration_test.rb
@@ -22,6 +22,7 @@ module Librato
         ENV["LIBRATO_TAGS"] = "hostname=metrics-web-stg-1"
         ENV['LIBRATO_PROXY'] = 'http://localhost:8080'
         ENV['LIBRATO_SUITES'] = 'foo,bar'
+        ENV['LIBRATO_PERCENTILES'] = '95,99'
         expected_tags = { hostname: "metrics-web-stg-1" }
         config = Configuration.new
         assert_equal 'foo@bar.com', config.user
@@ -29,6 +30,7 @@ module Librato
         assert_equal expected_tags, config.tags
         assert_equal 'http://localhost:8080', config.proxy
         assert_equal 'foo,bar', config.suites
+        assert_equal [95, 99], config.percentiles
         #assert Librato::Rails.explicit_source, 'source is explicit'
       end
 


### PR DESCRIPTION
Previously, we were limited to sending p95. This change allows the user to define a comma-delimited list of timing percentiles to be sent to Librato.